### PR TITLE
refactor: reorganize BedtimeProteinShake to match WakingBlueberryOatmealShakeFoodGroupings pattern

### DIFF
--- a/Executable/Data/TrainingWeeks/MuscleGain2.cs
+++ b/Executable/Data/TrainingWeeks/MuscleGain2.cs
@@ -12,7 +12,7 @@ internal record MuscleGain2 : TrainingWeekBase
             Meal.WithFallbacks("3-5 hours after last meal", new(P: MUSCLE_GAIN_PROTEIN_PER_MEAL_ON_NONWORKOUT_DAY, F: 20, C: 60), FoodGroupings.Ezekial),
             new("3-5 hours after last meal", new(P: MUSCLE_GAIN_PROTEIN_PER_MEAL_ON_NONWORKOUT_DAY, F: 20, C: 60), FoodGroupings.Tofu),
             new("3-5 hours after last meal", new(P: MUSCLE_GAIN_PROTEIN_PER_MEAL_ON_NONWORKOUT_DAY, F: 20, C: 60), FoodGroupings.Tofu),
-            BedtimeProteinShake()
+            Meal.WithFallbacks("Bedtime", new Macros(P: MUSCLE_GAIN_PROTEIN_PER_MEAL_ON_NONWORKOUT_DAY, F: 25, C: 0), BedtimeProteinShakeFoodGroupings)
         ],
         runningMeals:
         [
@@ -69,19 +69,12 @@ internal record MuscleGain2 : TrainingWeekBase
             Foods.Oats_1_Scoop,
             PreparationMethodEnum.PrepareAsNeeded))];
 
-    private static Meal BedtimeProteinShake() =>
-        Meal.WithFallbacks("Bedtime",
-            new Macros(P: MUSCLE_GAIN_PROTEIN_PER_MEAL_ON_NONWORKOUT_DAY, F: 25, C: 0),
-            new("Protein shake",
-                [Foods.AlmondMilk_2_Cup],
-                Foods.PeaProtein_1_Scoop,
-                Foods.AlmondButter_1_Tbsp,
-                Foods.BlueBerries_1_Scoop,
-                PreparationMethodEnum.PrepareAsNeeded),
-            new("Protein shake",
-                [Foods.AlmondMilk_2_Cup],
-                Foods.PeaProtein_1_Scoop,
-                Foods.AlmondButter_1_Tbsp,
-                Foods.FatToCarbConversion,
-                PreparationMethodEnum.PrepareAsNeeded));
+    private static readonly FoodGrouping[] BedtimeProteinShakeFoodGroupings =
+        [.. new[] { Foods.BlueBerries_1_Scoop, Foods.FatToCarbConversion }.Select(cFood =>
+        new FoodGrouping("Protein shake",
+            [Foods.AlmondMilk_2_Cup],
+            Foods.PeaProtein_1_Scoop,
+            Foods.AlmondButter_1_Tbsp,
+            cFood,
+            PreparationMethodEnum.PrepareAsNeeded))];
 }


### PR DESCRIPTION
## Summary
- Reorganized `BedtimeProteinShake` method into a static readonly field array to match the pattern used by `WakingBlueberryOatmealShakeFoodGroupings`
- Maintains the same functionality with two variations (BlueBerries_1_Scoop and FatToCarbConversion)
- Improves code consistency and organization in the MuscleGain2 class

## Test plan
- [ ] Verify that the MuscleGain2 meal plan still generates correctly
- [ ] Confirm that both protein shake variations are available as fallbacks
- [ ] Ensure no changes to the actual meal macros or food groupings

🤖 Generated with [Claude Code](https://claude.ai/code)