### PR TITLE
Fix water display in Todoist and increase Seitan water amount

### DIFF
--- a/Executable/CompositeFoodServing.cs
+++ b/Executable/CompositeFoodServing.cs
@@ -84,10 +84,10 @@ public record CompositeFoodServing : FoodServing
             // Water.PerServing is already scaled when the composite is multiplied
             // So we just use it directly with quantity=1 (since this is for display of the current serving)
             var waterAmount = Water.Base + Water.PerServing;
-            // Create a water serving with 1 serving unit of Cup, where the serving represents the water amount
+            // Create a water serving using Cup as the unit, with waterAmount as the serving size
             var waterServing = new FoodServing(
-                $"{waterAmount:f1} cups water",
-                new NutritionalInformation(1, ServingUnits.None, 0, 0, 0, 0, 0),
+                "water",
+                new NutritionalInformation(waterAmount, ServingUnits.Cup, 0, 0, 0, 0, 0),
                 null,
                 false);
             yield return waterServing;

--- a/Executable/Data/Foods.cs
+++ b/Executable/Data/Foods.cs
@@ -280,7 +280,7 @@ internal static class Foods
             NutritionalYeastFood.WithServing(4, ServingUnits.Gram),
             GlutenFood.WithServing(16, ServingUnits.Gram)
         ],
-        water: new(Base: 0, PerServing: 0.0366666666666667M));
+        water: new(Base: 0, PerServing: 0.1466666666666668M));
 
     public static FoodServing Whole_Grain_Pasta_56_Grams =>
         WholGrainPastaFood.WithServing(56, ServingUnits.Gram);

--- a/Test/CompositeFoodServingTests.cs
+++ b/Test/CompositeFoodServingTests.cs
@@ -187,7 +187,7 @@ public class CompositeFoodServingTests
 
         // Verify water component has correct amount
         var waterComponent = components.First(c => c.Name.Contains("water"));
-        Assert.Equal("0.0 cups water", waterComponent.Name);
+        Assert.Equal("water", waterComponent.Name);
     }
 
     [Fact]
@@ -215,8 +215,8 @@ public class CompositeFoodServingTests
 
         // Verify water component has scaled amount (0.0366666666666667 * 4 ≈ 0.147, rounds to 0.1)
         var waterComponent = components.First(c => c.Name.Contains("water"));
-        // Water amount should be rounded to 0.1
-        Assert.Equal("0.1 cups water", waterComponent.Name);
+        // Water component name should just be "water", the amount is in ServingUnits
+        Assert.Equal("water", waterComponent.Name);
     }
 
     [Fact]
@@ -273,8 +273,8 @@ public class CompositeFoodServingTests
         Assert.Equal("task_1", createdTasks[2].parentId); // Should be child of first created task
 
         // Fourth task should be water as subtask of Seitan
-        // The water component outputs as "1.0  0.0 cups water" due to how FoodServing.ToString() works
-        Assert.Equal("1.0  0.0 cups water", createdTasks[3].content);
+        // The water component now outputs properly formatted
+        Assert.Equal("0.0 cups water", createdTasks[3].content);
         Assert.Equal("task_1", createdTasks[3].parentId); // Should be child of first created task
     }
 
@@ -328,7 +328,7 @@ public class CompositeFoodServingTests
         // Components should be scaled
         Assert.Equal("8 grams nutritional yeast", createdTasks[1].content);
         Assert.Equal("32 grams gluten", createdTasks[2].content);
-        // Water component outputs with "1.0" prefix due to FoodServing.ToString()
-        Assert.Equal("1.0  0.0 cups water", createdTasks[3].content);
+        // Water component now outputs properly formatted
+        Assert.Equal("0.0 cups water", createdTasks[3].content);
     }
 }


### PR DESCRIPTION
## Summary
- Fixed confusing water display in Todoist output (was showing "1.0 0.1 cups water")
- Increased Seitan water amount by 4x as requested
- Updated tests to match new water formatting

## Changes
1. **Fixed water display formatting:**
   - Changed water FoodServing creation to use proper ServingUnit.Cup instead of ServingUnit.None
   - Water now displays cleanly as "0.1 cups water" instead of "1.0 0.1 cups water"

2. **Increased Seitan water amount:**
   - Multiplied water per serving from 0.0367 to 0.147 cups (4x increase)

3. **Updated tests:**
   - Updated test expectations to match the new water formatting
   - All 32 tests pass successfully

## Test plan
- [x] All existing unit tests pass
- [x] Manually verified water displays correctly in test program
- [x] Confirmed Seitan water amount is 4x higher

🤖 Generated with [Claude Code](https://claude.ai/code)