### PR TITLE
Collapse parent tasks with subtasks in Todoist

### DIFF
--- a/Executable/Todoist/TodoistApi.cs
+++ b/Executable/Todoist/TodoistApi.cs
@@ -13,8 +13,30 @@ internal static class TodoistApi
         result.EnsureSuccessStatusCode();
     }
 
+    public static async Task UpdateTaskCollapsedAsync(string taskId, bool collapsed)
+    {
+        using var httpClient = await CreateHttpClientAsync();
+        var result = await httpClient.PostAsJsonAsync("https://api.todoist.com/sync/v9/sync", new
+        {
+            Commands = new[]
+            {
+                new
+                {
+                    Type = "item_update",
+                    Uuid = Guid.NewGuid().ToString(),
+                    Args = new
+                    {
+                        Id = taskId,
+                        Collapsed = collapsed
+                    }
+                }
+            }
+        });
+        result.EnsureSuccessStatusCode();
+    }
+
     public static async Task<TodoistTask> AddTaskAsync(
-        string content, string? description, string? dueString, string? parentId, string? projectId)
+        string content, string? description, string? dueString, string? parentId, string? projectId, bool isCollapsed = false)
     {
         using var httpClient = await CreateHttpClientAsync();
         var result = await httpClient.PostAsJsonAsync("https://api.todoist.com/rest/v2/tasks", new
@@ -24,6 +46,7 @@ internal static class TodoistApi
             Parent_id = parentId,
             Project_id = projectId,
             Due_string = dueString,
+            Is_collapsed = isCollapsed,
         });
         result.EnsureSuccessStatusCode();
         var todoistTask = await result.Content.ReadFromJsonAsync<TodoistTask>();

--- a/Executable/Todoist/TodoistService.cs
+++ b/Executable/Todoist/TodoistService.cs
@@ -39,8 +39,10 @@ internal class TodoistService
             description: null,
             dueString: dueString,
             parentId: null,
-            project.Id);
+            project.Id,
+            isCollapsed: true);
         Console.WriteLine($"Added task {content}...");
+        await UpdateTaskCollapsedAsync(parentTodoistTask.Id, collapsed: true);
         await Task.WhenAll(servings.Select(s => AddServingAsync(parentTodoistTask, s)).ToList());
     }
 
@@ -50,8 +52,9 @@ internal class TodoistService
 
         Console.WriteLine($"Adding task {m.Name}...");
         var parentTodoistTask = await AddTaskAsync(
-            m.Name, description: null, dueString: "every tue", parentId: null, project.Id);
+            m.Name, description: null, dueString: "every tue", parentId: null, project.Id, isCollapsed: true);
         Console.WriteLine($"Added task {m.Name}");
+        await UpdateTaskCollapsedAsync(parentTodoistTask.Id, collapsed: true);
 
         // Create subtasks for each meal quantity - add sequentially to maintain order
         for (int mealCount = 1; mealCount <= m.MealCount; mealCount++)
@@ -70,8 +73,9 @@ internal class TodoistService
     {
         Console.WriteLine($"Adding subtask {parentTask.Content} > {quantityLabel}...");
         var quantityTask = await AddTaskAsync(
-            quantityLabel, description: null, dueString: null, parentTask.Id, projectId: null);
+            quantityLabel, description: null, dueString: null, parentTask.Id, projectId: null, isCollapsed: true);
         Console.WriteLine($"Added subtask {parentTask.Content} > {quantityLabel}");
+        await UpdateTaskCollapsedAsync(quantityTask.Id, collapsed: true);
 
         // Scale servings based on meal count ratio
         decimal scaleFactor = (decimal)mealCount / totalMealCount;
@@ -120,8 +124,9 @@ internal class TodoistService
             Console.WriteLine($"Adding task {content}...");
             var parentTodoistTask = await AddTaskAsync(
                 content, $"Synced on {DateTime.Now}",
-                x.DueString, parentId: null, eatingProject.Id);
+                x.DueString, parentId: null, eatingProject.Id, isCollapsed: true);
             Console.WriteLine($"Added task {content}");
+            await UpdateTaskCollapsedAsync(parentTodoistTask.Id, collapsed: true);
 
             // Add child tasks in parallel
             systemTasks.AddRange(x.Meal.Servings.Where(s => !s.IsConversion)


### PR DESCRIPTION
## Summary
- Added support for collapsing tasks with subtasks in Todoist to improve navigation
- Implemented hybrid approach using REST API v2 for task creation and Sync API v9 for setting collapsed state
- All parent tasks (meal prep plans, quantity subtasks, and eating tasks) now appear collapsed by default

## Technical Details
Since REST API v2 doesn't support the `is_collapsed` parameter, this implementation:
1. Creates tasks using REST API v2
2. Immediately updates the collapsed state using Sync API v9's `item_update` command

## Test plan
- [ ] Run the sync and verify all parent tasks appear collapsed in Todoist
- [ ] Verify subtasks are still accessible by expanding parent tasks
- [ ] Confirm all nutritional comments are still added correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)