### PR TITLE
Add low sodium Ezekial bread meal updates

### DIFF
--- a/Executable/Data/FoodGroupings.cs
+++ b/Executable/Data/FoodGroupings.cs
@@ -164,26 +164,6 @@ internal static class FoodGroupings
         Foods.WheatBerries_45_Grams,
         PreparationMethodEnum.PrepareInAdvance);
 
-    public static FallbackChain WorkoutMeal { get; } = new(
-        new FoodGrouping(
-            "workout shake",
-            Foods.Edamame_1_Scoop,
-            Foods.FatToCarbConversion,
-            Foods.OrangeJuice_1_Cup,
-            PreparationMethodEnum.PrepareAsNeeded),
-        new FoodGrouping(
-            "workout shake",
-            Foods.FatToCarbConversion,
-            Foods.FatToCarbConversion,
-            Foods.OrangeJuice_1_Cup,
-            PreparationMethodEnum.PrepareAsNeeded),
-        new FoodGrouping(
-            "workout shake",
-            Foods.ProteinToCarbConversion,
-            Foods.FatToCarbConversion,
-            Foods.OrangeJuice_1_Cup,
-            PreparationMethodEnum.PrepareAsNeeded));
-
     public static FoodGrouping WorkoutShake { get; } = new(
         "workout shake",
         Foods.PeaProtein_1_Scoop,

--- a/Executable/Data/Foods.cs
+++ b/Executable/Data/Foods.cs
@@ -57,6 +57,10 @@ internal static class Foods
         [(0.5M, ServingUnits.Cup)],
         new BaseNutrition(Cals: 190, P: 8, F: 1, CTotal: 38, CFiber: 7));
 
+    private static Food EzekialBreadLowSodiumFood { get; } = new("Ezekial Bread Low Sodium",
+        [(1, ServingUnits.Slice), (34, ServingUnits.Gram)],
+        new BaseNutrition(Cals: 80, P: 5, F: 0.5M, CTotal: 15, CFiber: 3));
+
     private static Food EzekielEnglishMuffinFood { get; } = new("Ezekiel english muffin",
         [(0.5M, ServingUnits.None)],
         new BaseNutrition(Cals: 90, P: 6, F: 0.5M, CTotal: 17, CFiber: 3));
@@ -240,6 +244,12 @@ internal static class Foods
 
     public static FoodServing Ezeliel_Cereal_Low_Sodium_1_2_Cup =>
         EzekielCerealLowSodiumFood.WithServing(0.5M, ServingUnits.Cup);
+
+    public static FoodServing Ezekial_Bread_Low_Sodium_1_Slice =>
+        EzekialBreadLowSodiumFood.WithServing(1, ServingUnits.Slice) with
+        {
+            AddWhen = FoodServing.AddWhenEnum.AtEatingTime
+        };
 
     public static FoodServing Ezekiel_English_Muffin =>
         EzekielEnglishMuffinFood.WithServing(1, ServingUnits.None) with

--- a/Executable/Data/ServingUnits.cs
+++ b/Executable/Data/ServingUnits.cs
@@ -7,6 +7,7 @@ public static class ServingUnits
     public static readonly ServingUnit Cup = new("cup", decimalsToDisplay: 1);
     public static readonly ServingUnit Gram = new("gram", decimalsToDisplay: 0);
     public static readonly ServingUnit Meal = new("meal", decimalsToDisplay: 0);
+    public static readonly ServingUnit Slice = new("slice", decimalsToDisplay: 1);
     public static readonly ServingUnit Scoop = new("scoop", decimalsToDisplay: 1, unitConversion: (0.380408M, Unit: Cup));
     public static readonly ServingUnit Tablespoon = new("tbsp", decimalsToDisplay: 1, unitConversion: (1M / 16, Cup));
 }

--- a/Executable/Data/TrainingWeeks/MuscleGain2.cs
+++ b/Executable/Data/TrainingWeeks/MuscleGain2.cs
@@ -25,7 +25,7 @@ internal record MuscleGain2 : TrainingWeekBase
                 new Macros(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 20, C: 50),
                 FoodGroupings.BlueberriesOatmealAndEdamame + Foods.Creatine_1_Scoop),
             new("1/2 shake during workout, 1/2 right after",
-                new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 0, C: 35), FoodGroupings.WorkoutMeal),
+                new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 0, C: 35), WorkoutMeal),
             new Meal("40 minutes after workout", new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 10, C: 100),
                 FoodGroupings.Ezekiel),
             new("2-4 hours after last meal", new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 20, C: 65),
@@ -40,7 +40,7 @@ internal record MuscleGain2 : TrainingWeekBase
             new Meal("1-3 hours before workout", new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 20, C: 80),
                 Oatmeal),
             new("1/2 shake during workout, 1/2 right after",
-                new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 0, C: 35), FoodGroupings.WorkoutMeal),
+                new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 0, C: 35), WorkoutMeal),
             new Meal("40 minutes after workout", new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 10, C: 120),
                 FoodGroupings.Ezekiel),
             new Meal("2-4 hours after last meal", new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 20, C: 100),
@@ -87,6 +87,26 @@ internal record MuscleGain2 : TrainingWeekBase
                 PreparationMethodEnum.PrepareInAdvance),
             FoodGroupings.Tofu
         });
+
+    private static FallbackChain WorkoutMeal { get; } = new(
+        new FoodGrouping(
+            "workout shake",
+            Foods.Edamame_1_Scoop,
+            Foods.FatToCarbConversion,
+            Foods.OrangeJuice_1_Cup,
+            PreparationMethodEnum.PrepareAsNeeded),
+        new FoodGrouping(
+            "workout shake",
+            Foods.FatToCarbConversion,
+            Foods.FatToCarbConversion,
+            Foods.OrangeJuice_1_Cup,
+            PreparationMethodEnum.PrepareAsNeeded),
+        new FoodGrouping(
+            "workout shake",
+            Foods.ProteinToCarbConversion,
+            Foods.FatToCarbConversion,
+            Foods.OrangeJuice_1_Cup,
+            PreparationMethodEnum.PrepareAsNeeded));
 
     private static readonly FallbackChain NonworkoutWakingOatmealFoodGroupings = new(
         [.. new[] { Foods.AlmondButter_1_Tbsp, Foods.FatToCarbConversion }.Select(fFood =>

--- a/Executable/Data/TrainingWeeks/MuscleGain3/MuscleGain3TrainingAfter1Meal.cs
+++ b/Executable/Data/TrainingWeeks/MuscleGain3/MuscleGain3TrainingAfter1Meal.cs
@@ -16,6 +16,7 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
                 Cereal),
             new("3-5 hours after last meal",
                 new(P: MuscleGainProteinPerMealOnNonworkoutDay(targetGramsProteinPerDay), F: 20, C: 60),
+                //FoodGroupings.EnglishMuffinsAndPasta(0)),
                 TofuAndEnglishMuffin),
             new Meal("3-5 hours after last meal",
                 new(P: MuscleGainProteinPerMealOnNonworkoutDay(targetGramsProteinPerDay), F: 20, C: 60),
@@ -32,10 +33,10 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
                 Oatmeal(blueberryScoops: 3)),
             new("1/2 shake during workout, 1/2 right after",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 0, C: 55),
-                FoodGroupings.WorkoutMeal),
+                WorkoutMeal),
             new Meal("40 minutes after workout",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 10, C: 120),
-                SeitanAndEnglishMuffin),
+                ToastAndAlmondButter),
                 //FoodGroupings.EnglishMuffinsAndPasta(0)),
             new("2-4 hours after last meal",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 20, C: 100),
@@ -55,10 +56,10 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
                 Oatmeal(blueberryScoops: 3)),
             new("1/2 shake during workout, 1/2 right after",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 0, C: 55),
-                FoodGroupings.WorkoutMeal),
+                WorkoutMeal),
             new Meal("40 minutes after workout",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 10, C: 120),
-                Cereal),
+                ToastAndAlmondButter),
             new("2-4 hours after last meal",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 20, C: 100),
                 EnglishMuffinsAndRice),
@@ -96,6 +97,34 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
             Foods.Edamame_1_Scoop,
             Foods.FatToCarbConversion,
             Foods.FiberOne_2_3_Cup,
+            PreparationMethodEnum.PrepareAsNeeded));
+
+    private static readonly FoodGrouping ToastAndAlmondButter = new(
+        "Fiber One",
+        [Foods.OrangeJuice_1_Cup * 2],
+        Foods.AlmondButter_1_Tbsp,
+        Foods.Edamame_1_Scoop,
+        Foods.Ezekial_Bread_Low_Sodium_1_Slice,
+        PreparationMethodEnum.PrepareAsNeeded);
+
+    private static FallbackChain WorkoutMeal { get; } = new(
+        new FoodGrouping(
+            "workout shake",
+            Foods.Edamame_1_Scoop,
+            Foods.FatToCarbConversion,
+            Foods.Ezekial_Bread_Low_Sodium_1_Slice,
+            PreparationMethodEnum.PrepareAsNeeded),
+        new FoodGrouping(
+            "workout shake",
+            Foods.FatToCarbConversion,
+            Foods.FatToCarbConversion,
+            Foods.OrangeJuice_1_Cup,
+            PreparationMethodEnum.PrepareAsNeeded),
+        new FoodGrouping(
+            "workout shake",
+            Foods.ProteinToCarbConversion,
+            Foods.FatToCarbConversion,
+            Foods.OrangeJuice_1_Cup,
             PreparationMethodEnum.PrepareAsNeeded));
 
     private static FallbackChain Oatmeal(int blueberryScoops) => new(


### PR DESCRIPTION
## Summary
- add Ezekial Bread Low Sodium as a slice/gram food serving
- include the bread in MuscleGain3TrainingAfter1Meal workout-specific meals
- move WorkoutMeal out of shared FoodGroupings and localize existing uses

## Validation
- dotnet test --no-restore
- dotnet format --verify-no-changes --no-restore