### PR TITLE
Support 2,800-calorie meal plan scaling

### DIFF
--- a/Executable/Data/TrainingWeeks/MuscleGain3/MuscleGain3TrainingAfter1Meal.cs
+++ b/Executable/Data/TrainingWeeks/MuscleGain3/MuscleGain3TrainingAfter1Meal.cs
@@ -92,13 +92,6 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
             Foods.Edamame_1_Scoop,
             Foods.FatToCarbConversion,
             Foods.FiberOne_2_3_Cup,
-            PreparationMethodEnum.PrepareAsNeeded),
-        new FoodGrouping(
-            "Fiber One",
-            [Foods.AlmondMilk_1_Scoop * 2],
-            Foods.Edamame_1_Scoop,
-            Foods.FatToCarbConversion,
-            Foods.FiberOne_2_3_Cup,
             PreparationMethodEnum.PrepareAsNeeded));
 
     private static FallbackChain ToastAndAlmondButter(bool withOrangeJuice)

--- a/Executable/Data/TrainingWeeks/MuscleGain3/MuscleGain3TrainingAfter1Meal.cs
+++ b/Executable/Data/TrainingWeeks/MuscleGain3/MuscleGain3TrainingAfter1Meal.cs
@@ -17,10 +17,10 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
             new("3-5 hours after last meal",
                 new(P: MuscleGainProteinPerMealOnNonworkoutDay(targetGramsProteinPerDay), F: 20, C: 60),
                 //FoodGroupings.EnglishMuffinsAndPasta(0)),
-                TofuAndEnglishMuffin),
+                SeitanAndEnglishMuffin),
             new Meal("3-5 hours after last meal",
                 new(P: MuscleGainProteinPerMealOnNonworkoutDay(targetGramsProteinPerDay), F: 20, C: 60),
-                TofuAndEnglishMuffin),
+                SeitanAndEnglishMuffin),
                 //FoodGroupings.EnglishMuffinsAndPasta(0)),
             new Meal("Bedtime",
                 new Macros(P: MuscleGainProteinPerMealOnNonworkoutDay(targetGramsProteinPerDay), F: 25, C: 0),
@@ -36,18 +36,20 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
                 WorkoutMeal),
             new Meal("40 minutes after workout",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 10, C: 120),
-                ToastAndAlmondButter),
-                //FoodGroupings.EnglishMuffinsAndPasta(0)),
+                //SeitanAndEnglishMuffin),
+                //Cereal),
+                FoodGroupings.EnglishMuffinsAndPasta(0)),
             new("2-4 hours after last meal",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 20, C: 100),
-                //FoodGroupings.EnglishMuffinsAndPasta(0)),
-                SeitanAndEnglishMuffin),
+                FoodGroupings.EnglishMuffinsAndPasta(0)),
+                //SeitanAndEnglishMuffin),
             new("3-5 hours after last meal",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 20, C: 50),
-                Cereal),
+                ToastAndAlmondButter(withOrangeJuice: false)),
             new Meal("Bedtime",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 25, C: 35),
-                FoodGroupings.EnglishMuffinsAndPasta(englishMuffins: 0)),
+                //FoodGroupings.EnglishMuffinsAndPasta(englishMuffins: 0)),
+                Cereal),
         ],
         xfitMeals:
         [
@@ -59,7 +61,7 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
                 WorkoutMeal),
             new Meal("40 minutes after workout",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 10, C: 120),
-                ToastAndAlmondButter),
+                ToastAndAlmondButter(withOrangeJuice: true)),
             new("2-4 hours after last meal",
                 new(P: MuscleGainProteinPerMealOnWorkoutDay(targetGramsProteinPerDay), F: 20, C: 100),
                 EnglishMuffinsAndRice),
@@ -87,8 +89,8 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
         new FoodGrouping(
             "Fiber One",
             [Foods.AlmondMilk_1_Scoop * 2],
-            Foods.PumpkinSeeds_1_Scoop,
-            Foods.ProteinToCarbConversion,
+            Foods.Edamame_1_Scoop,
+            Foods.FatToCarbConversion,
             Foods.FiberOne_2_3_Cup,
             PreparationMethodEnum.PrepareAsNeeded),
         new FoodGrouping(
@@ -99,13 +101,25 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
             Foods.FiberOne_2_3_Cup,
             PreparationMethodEnum.PrepareAsNeeded));
 
-    private static readonly FoodGrouping ToastAndAlmondButter = new(
-        "Fiber One",
-        [Foods.OrangeJuice_1_Cup * 2],
-        Foods.AlmondButter_1_Tbsp,
-        Foods.Edamame_1_Scoop,
-        Foods.Ezekial_Bread_Low_Sodium_1_Slice,
-        PreparationMethodEnum.PrepareAsNeeded);
+    private static FallbackChain ToastAndAlmondButter(bool withOrangeJuice)
+    {
+        FoodServing[] staticServings = withOrangeJuice ? [Foods.OrangeJuice_1_Cup * 2] : [];
+        return new(
+            new FoodGrouping(
+                "toast and almond butter",
+                staticServings,
+                Foods.Edamame_1_Scoop,
+                Foods.AlmondButter_1_Tbsp,
+                Foods.Ezekial_Bread_Low_Sodium_1_Slice,
+                PreparationMethodEnum.PrepareAsNeeded),
+            new FoodGrouping(
+                "toast and almond butter",
+                staticServings,
+                Foods.Edamame_1_Scoop,
+                Foods.FatToCarbConversion,
+                Foods.Ezekial_Bread_Low_Sodium_1_Slice,
+                PreparationMethodEnum.PrepareAsNeeded));
+    }
 
     private static FallbackChain WorkoutMeal { get; } = new(
         new FoodGrouping(
@@ -148,7 +162,15 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
             pFood,
             Foods.PumpkinSeeds_30_Grams,
             Foods.BrownRice_45_Grams,
-            PreparationMethodEnum.PrepareInAdvance)).ToArray());
+            PreparationMethodEnum.PrepareInAdvance))
+        .Append(new FoodGrouping(
+            "rice",
+            [Foods.Ezekiel_English_Muffin, Foods.AlmondButter_1_Tbsp],
+            Foods.ProteinToCarbConversion,
+            Foods.FatToCarbConversion,
+            Foods.BrownRice_45_Grams,
+            PreparationMethodEnum.PrepareInAdvance))
+        .ToArray());
 
     private static readonly FoodGrouping SeitanAndEnglishMuffin = new(
         "seitan and english muffin",
@@ -191,11 +213,12 @@ internal record MuscleGain3TrainingAfter1Meal : TrainingWeekBase
             PreparationMethodEnum.PrepareAsNeeded))]);
 
     private static readonly FallbackChain NonworkoutBedtimeFoodGroupings = new(
-        [.. new[] { Foods.Whole_Grain_Pasta_56_Grams, Foods.FatToCarbConversion }.Select(cFood =>
-        new FoodGrouping("Protein shake",
+        [.. new[] { Foods.Whole_Grain_Pasta_56_Grams, Foods.FatToCarbConversion }.SelectMany(cFood =>
+            new[] { Foods.PumpkinSeeds_1_Scoop, Foods.FatToProteinConversion }.Select(fFood =>
+        new FoodGrouping("Edamame",
             Foods.Edamame_1_Scoop,
-            Foods.PumpkinSeeds_1_Scoop,
+            fFood,
             cFood,
-            PreparationMethodEnum.PrepareAsNeeded))]);
+            PreparationMethodEnum.PrepareAsNeeded)))]);
 
 }

--- a/Executable/Data/TrainingWeeks/TrainingWeekBase.cs
+++ b/Executable/Data/TrainingWeeks/TrainingWeekBase.cs
@@ -36,10 +36,15 @@ internal abstract record TrainingWeekBase : TrainingWeek
         TrainingWeek bestWeek = this;
         var baseAverage = CalculateAverageDailyCalories(this);
         var bestDifference = Math.Abs(baseAverage - targetDailyCalories);
-        const decimal epsilon = 0.01M;
         const decimal acceptableCalorieDifference = 0.1M;
         var bestPercent = 100M;
         List<(decimal Percent, FoodGroupingCalculationException Exception)> failedCandidates = [];
+        TrainingWeek? closestWeekBelowTarget = null;
+        TrainingWeek? closestWeekAboveTarget = null;
+        var closestDifferenceBelowTarget = decimal.MaxValue;
+        var closestDifferenceAboveTarget = decimal.MaxValue;
+
+        RecordCandidate(100M, this, baseAverage);
 
         if (bestDifference <= acceptableCalorieDifference)
         {
@@ -59,7 +64,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
 
             while (TryCalculateCandidate(high, out var highWeek, out var highAverageDailyCals))
             {
-                UpdateBest(high, highWeek, highAverageDailyCals);
+                RecordCandidate(high, highWeek, highAverageDailyCals);
                 if (highAverageDailyCals >= targetDailyCalories)
                 {
                     break;
@@ -77,7 +82,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
 
             while (TryCalculateCandidate(low, out var lowWeek, out var lowAverageDailyCals))
             {
-                UpdateBest(low, lowWeek, lowAverageDailyCals);
+                RecordCandidate(low, lowWeek, lowAverageDailyCals);
                 if (lowAverageDailyCals <= targetDailyCalories || low == 0M)
                 {
                     break;
@@ -89,9 +94,14 @@ internal abstract record TrainingWeekBase : TrainingWeek
             }
         }
 
-        while (high - low > epsilon)
+        while (bestDifference > acceptableCalorieDifference)
         {
             var mid = (low + high) / 2;
+            if (mid == low || mid == high)
+            {
+                break;
+            }
+
             if (!TryCalculateCandidate(mid, out var testWeek, out var averageDailyCals))
             {
                 if (mid > 100M)
@@ -105,13 +115,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
                 continue;
             }
 
-            UpdateBest(mid, testWeek, averageDailyCals);
-
-            // Stop if we're close enough
-            if (bestDifference <= acceptableCalorieDifference)
-            {
-                break;
-            }
+            RecordCandidate(mid, testWeek, averageDailyCals);
 
             // Adjust search range
             if (averageDailyCals < targetDailyCalories)
@@ -132,8 +136,10 @@ internal abstract record TrainingWeekBase : TrainingWeek
                 $"{targetDailyCalories:F0} calories/day with the configured " +
                 $"food groupings. The closest achievable average is {bestAverageDailyCalories:F0} calories/day. " +
                 "Add or adjust meal fallback food groupings to support this target.";
-            FoodGroupingCalculationException? limitingException = null;
-            if (failedCandidates.Count > 0)
+            var limitingException = closestWeekBelowTarget != null && closestWeekAboveTarget != null
+                ? FindFallbackTransition(closestWeekBelowTarget, closestWeekAboveTarget)
+                : null;
+            if (limitingException == null && failedCandidates.Count > 0)
             {
                 limitingException = failedCandidates
                     .MinBy(failure => Math.Abs(failure.Percent - bestPercent))
@@ -150,9 +156,20 @@ internal abstract record TrainingWeekBase : TrainingWeek
 
         return bestWeek;
 
-        void UpdateBest(decimal percent, TrainingWeek week, decimal averageDailyCals)
+        void RecordCandidate(decimal percent, TrainingWeek week, decimal averageDailyCals)
         {
             var difference = Math.Abs(averageDailyCals - targetDailyCalories);
+            if (averageDailyCals < targetDailyCalories && difference < closestDifferenceBelowTarget)
+            {
+                closestDifferenceBelowTarget = difference;
+                closestWeekBelowTarget = week;
+            }
+            else if (averageDailyCals > targetDailyCalories && difference < closestDifferenceAboveTarget)
+            {
+                closestDifferenceAboveTarget = difference;
+                closestWeekAboveTarget = week;
+            }
+
             if (difference < bestDifference)
             {
                 bestDifference = difference;
@@ -212,5 +229,53 @@ internal abstract record TrainingWeekBase : TrainingWeek
         }
 
         return totalCals / 7;
+    }
+
+    private static FoodGroupingCalculationException? FindFallbackTransition(
+        TrainingWeek weekBelowTarget,
+        TrainingWeek weekAboveTarget)
+    {
+        var daysBelowTarget = weekBelowTarget.TrainingDays.ToArray();
+        var daysAboveTarget = weekAboveTarget.TrainingDays.ToArray();
+
+        for (var dayIndex = 0; dayIndex < daysBelowTarget.Length; dayIndex++)
+        {
+            var mealsBelowTarget = daysBelowTarget[dayIndex].Meals.ToArray();
+            var mealsAboveTarget = daysAboveTarget[dayIndex].Meals.ToArray();
+
+            for (var mealIndex = 0; mealIndex < mealsBelowTarget.Length; mealIndex++)
+            {
+                var mealBelowTarget = mealsBelowTarget[mealIndex];
+                var mealAboveTarget = mealsAboveTarget[mealIndex];
+                if (ReferenceEquals(mealBelowTarget.FoodGrouping, mealAboveTarget.FoodGrouping))
+                {
+                    continue;
+                }
+
+                var groupingIndexBelowTarget = Array.IndexOf(
+                    mealBelowTarget.FoodGroupings,
+                    mealBelowTarget.FoodGrouping);
+                var groupingIndexAboveTarget = Array.IndexOf(
+                    mealAboveTarget.FoodGroupings,
+                    mealAboveTarget.FoodGrouping);
+                var mealUsingLaterFallback = groupingIndexBelowTarget > groupingIndexAboveTarget
+                    ? mealBelowTarget
+                    : mealAboveTarget;
+                var failedGroupingIndex = Math.Min(groupingIndexBelowTarget, groupingIndexAboveTarget);
+                if (failedGroupingIndex < 0 ||
+                    failedGroupingIndex >= mealUsingLaterFallback.FailedFoodGroupingCalculations.Count)
+                {
+                    continue;
+                }
+
+                var calculationException =
+                    mealUsingLaterFallback.FailedFoodGroupingCalculations[failedGroupingIndex];
+                return new FoodGroupingCalculationException(
+                    $"{daysBelowTarget[dayIndex].TrainingDayType} > {calculationException.Message}",
+                    calculationException);
+            }
+        }
+
+        return null;
     }
 }

--- a/Executable/Data/TrainingWeeks/TrainingWeekBase.cs
+++ b/Executable/Data/TrainingWeeks/TrainingWeekBase.cs
@@ -36,7 +36,9 @@ internal abstract record TrainingWeekBase : TrainingWeek
         TrainingWeek bestWeek = this;
         var baseAverage = CalculateAverageDailyCalories(this);
         var bestDifference = Math.Abs(baseAverage - targetDailyCalories);
-        decimal epsilon = 0.01M;
+        const decimal epsilon = 0.01M;
+        const decimal acceptableCalorieDifferenceRatio = 0.01M;
+        Exception? limitingException = null;
 
         if (bestDifference < 0.1M)
         {
@@ -54,7 +56,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
             low = 100M;
             high = Math.Max(percentNeeded + 10M, 110M);
 
-            while (TryCalculateAverageDailyCalories(high, out var highWeek, out var highAverageDailyCals))
+            while (TryCalculateCandidate(high, out var highWeek, out var highAverageDailyCals))
             {
                 UpdateBest(highWeek, highAverageDailyCals);
                 if (highAverageDailyCals >= targetDailyCalories)
@@ -72,7 +74,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
             high = 100M;
             low = Math.Max(0M, Math.Min(percentNeeded - 10M, 90M));
 
-            while (TryCalculateAverageDailyCalories(low, out var lowWeek, out var lowAverageDailyCals))
+            while (TryCalculateCandidate(low, out var lowWeek, out var lowAverageDailyCals))
             {
                 UpdateBest(lowWeek, lowAverageDailyCals);
                 if (lowAverageDailyCals <= targetDailyCalories || low == 0M)
@@ -89,7 +91,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
         while (high - low > epsilon)
         {
             var mid = (low + high) / 2;
-            if (!TryCalculateAverageDailyCalories(mid, out var testWeek, out var averageDailyCals))
+            if (!TryCalculateCandidate(mid, out var testWeek, out var averageDailyCals))
             {
                 if (mid > 100M)
                 {
@@ -121,6 +123,22 @@ internal abstract record TrainingWeekBase : TrainingWeek
             }
         }
 
+        var acceptableCalorieDifference = targetDailyCalories * acceptableCalorieDifferenceRatio;
+        if (bestDifference > acceptableCalorieDifference)
+        {
+            var bestAverageDailyCalories = CalculateAverageDailyCalories(bestWeek);
+            var message =
+                $"Unable to get within 1% of the target average of {targetDailyCalories:F0} calories/day with the configured " +
+                $"food groupings. The closest achievable average is {bestAverageDailyCalories:F0} calories/day. " +
+                "Add or adjust meal fallback food groupings to support this target.";
+            if (limitingException != null)
+            {
+                message += $" Limiting calculation: {limitingException.Message}";
+            }
+
+            throw new InvalidOperationException(message, limitingException);
+        }
+
         return bestWeek;
 
         void UpdateBest(TrainingWeek week, decimal averageDailyCals)
@@ -132,23 +150,44 @@ internal abstract record TrainingWeekBase : TrainingWeek
                 bestWeek = week;
             }
         }
+
+        bool TryCalculateCandidate(
+            decimal percent,
+            out TrainingWeek trainingWeek,
+            out decimal averageDailyCals)
+        {
+            var success = TryCalculateAverageDailyCalories(
+                percent,
+                out trainingWeek,
+                out averageDailyCals,
+                out var calculationException);
+            if (!success && limitingException == null)
+            {
+                limitingException = calculationException;
+            }
+
+            return success;
+        }
     }
 
     private bool TryCalculateAverageDailyCalories(
         decimal percent,
         out TrainingWeek trainingWeek,
-        out decimal averageDailyCals)
+        out decimal averageDailyCals,
+        out Exception? calculationException)
     {
         trainingWeek = PlusPercent(percent);
+        calculationException = null;
         try
         {
             averageDailyCals = CalculateAverageDailyCalories(trainingWeek);
             return true;
         }
-        catch (Exception)
+        catch (Exception exception)
         {
             // Some percentages cannot be solved because every fallback produces invalid servings.
             averageDailyCals = 0M;
+            calculationException = exception;
             return false;
         }
     }

--- a/Executable/Data/TrainingWeeks/TrainingWeekBase.cs
+++ b/Executable/Data/TrainingWeeks/TrainingWeekBase.cs
@@ -37,10 +37,11 @@ internal abstract record TrainingWeekBase : TrainingWeek
         var baseAverage = CalculateAverageDailyCalories(this);
         var bestDifference = Math.Abs(baseAverage - targetDailyCalories);
         const decimal epsilon = 0.01M;
-        const decimal acceptableCalorieDifferenceRatio = 0.01M;
-        Exception? limitingException = null;
+        const decimal acceptableCalorieDifference = 0.1M;
+        var bestPercent = 100M;
+        List<(decimal Percent, FoodGroupingCalculationException Exception)> failedCandidates = [];
 
-        if (bestDifference < 0.1M)
+        if (bestDifference <= acceptableCalorieDifference)
         {
             return bestWeek;
         }
@@ -58,7 +59,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
 
             while (TryCalculateCandidate(high, out var highWeek, out var highAverageDailyCals))
             {
-                UpdateBest(highWeek, highAverageDailyCals);
+                UpdateBest(high, highWeek, highAverageDailyCals);
                 if (highAverageDailyCals >= targetDailyCalories)
                 {
                     break;
@@ -76,7 +77,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
 
             while (TryCalculateCandidate(low, out var lowWeek, out var lowAverageDailyCals))
             {
-                UpdateBest(lowWeek, lowAverageDailyCals);
+                UpdateBest(low, lowWeek, lowAverageDailyCals);
                 if (lowAverageDailyCals <= targetDailyCalories || low == 0M)
                 {
                     break;
@@ -104,10 +105,10 @@ internal abstract record TrainingWeekBase : TrainingWeek
                 continue;
             }
 
-            UpdateBest(testWeek, averageDailyCals);
+            UpdateBest(mid, testWeek, averageDailyCals);
 
             // Stop if we're close enough
-            if (bestDifference < 0.1M)
+            if (bestDifference <= acceptableCalorieDifference)
             {
                 break;
             }
@@ -123,14 +124,22 @@ internal abstract record TrainingWeekBase : TrainingWeek
             }
         }
 
-        var acceptableCalorieDifference = targetDailyCalories * acceptableCalorieDifferenceRatio;
         if (bestDifference > acceptableCalorieDifference)
         {
             var bestAverageDailyCalories = CalculateAverageDailyCalories(bestWeek);
             var message =
-                $"Unable to get within 1% of the target average of {targetDailyCalories:F0} calories/day with the configured " +
+                $"Unable to get within {acceptableCalorieDifference:F1} calories/day of the target average of " +
+                $"{targetDailyCalories:F0} calories/day with the configured " +
                 $"food groupings. The closest achievable average is {bestAverageDailyCalories:F0} calories/day. " +
                 "Add or adjust meal fallback food groupings to support this target.";
+            FoodGroupingCalculationException? limitingException = null;
+            if (failedCandidates.Count > 0)
+            {
+                limitingException = failedCandidates
+                    .MinBy(failure => Math.Abs(failure.Percent - bestPercent))
+                    .Exception;
+            }
+
             if (limitingException != null)
             {
                 message += $" Limiting calculation: {limitingException.Message}";
@@ -141,12 +150,13 @@ internal abstract record TrainingWeekBase : TrainingWeek
 
         return bestWeek;
 
-        void UpdateBest(TrainingWeek week, decimal averageDailyCals)
+        void UpdateBest(decimal percent, TrainingWeek week, decimal averageDailyCals)
         {
             var difference = Math.Abs(averageDailyCals - targetDailyCalories);
             if (difference < bestDifference)
             {
                 bestDifference = difference;
+                bestPercent = percent;
                 bestWeek = week;
             }
         }
@@ -161,9 +171,9 @@ internal abstract record TrainingWeekBase : TrainingWeek
                 out trainingWeek,
                 out averageDailyCals,
                 out var calculationException);
-            if (!success && limitingException == null)
+            if (!success && calculationException != null)
             {
-                limitingException = calculationException;
+                failedCandidates.Add((percent, calculationException));
             }
 
             return success;
@@ -174,7 +184,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
         decimal percent,
         out TrainingWeek trainingWeek,
         out decimal averageDailyCals,
-        out Exception? calculationException)
+        out FoodGroupingCalculationException? calculationException)
     {
         trainingWeek = PlusPercent(percent);
         calculationException = null;
@@ -183,7 +193,7 @@ internal abstract record TrainingWeekBase : TrainingWeek
             averageDailyCals = CalculateAverageDailyCalories(trainingWeek);
             return true;
         }
-        catch (Exception exception)
+        catch (FoodGroupingCalculationException exception)
         {
             // Some percentages cannot be solved because every fallback produces invalid servings.
             averageDailyCals = 0M;

--- a/Executable/FoodGroupingCalculationException.cs
+++ b/Executable/FoodGroupingCalculationException.cs
@@ -1,0 +1,12 @@
+namespace SystemOfEquations;
+
+internal sealed class FoodGroupingCalculationException : Exception
+{
+    public FoodGroupingCalculationException(string message) : base(message)
+    {
+    }
+
+    public FoodGroupingCalculationException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/Executable/Meal.cs
+++ b/Executable/Meal.cs
@@ -112,7 +112,7 @@ public class Meal
 
         if (solution == null)
         {
-            throw new Exception("No solution");
+            throw new Exception($"{Name} > {foodGrouping.Name} > No solution.");
         }
 
         (var pFoodServings, var fFoodServings, var cFoodServings) = solution.Value;
@@ -128,7 +128,9 @@ public class Meal
         {
             if (serving.NutritionalInformation.ServingUnits < 0 && !serving.IsConversion)
             {
-                throw new Exception($"{Name} > {serving.NutritionalInformation.ServingUnits:F2} servings in {serving.Name}.");
+                throw new Exception(
+                    $"{Name} > {foodGrouping.Name} > " +
+                    $"{serving.NutritionalInformation.ServingUnits:F2} servings in {serving.Name}.");
             }
         }
 

--- a/Executable/Meal.cs
+++ b/Executable/Meal.cs
@@ -65,6 +65,7 @@ public class Meal
         }
     }
     public FoodGrouping? ActualFoodGrouping { get; private set; }
+    internal IReadOnlyList<FoodGroupingCalculationException> FailedFoodGroupingCalculations { get; private set; } = [];
 
     private IEnumerable<FoodServing>? _servings = null;
     public IEnumerable<FoodServing> Servings
@@ -76,7 +77,7 @@ public class Meal
                 return _servings;
             }
 
-            FoodGroupingCalculationException? lastException = null;
+            List<FoodGroupingCalculationException> calculationExceptions = [];
 
             foreach (var foodGrouping in _foodGroupings)
             {
@@ -85,15 +86,17 @@ public class Meal
                     var calculatedServings = TryCalculateServings(foodGrouping);
                     _servings = calculatedServings;
                     ActualFoodGrouping = foodGrouping;
+                    FailedFoodGroupingCalculations = [.. calculationExceptions];
                     return _servings;
                 }
                 catch (FoodGroupingCalculationException ex)
                 {
-                    lastException = ex;
+                    calculationExceptions.Add(ex);
                 }
             }
 
-            throw lastException ?? new FoodGroupingCalculationException("No FoodGroupings provided");
+            throw calculationExceptions.LastOrDefault() ??
+                new FoodGroupingCalculationException("No FoodGroupings provided");
         }
     }
 

--- a/Executable/Meal.cs
+++ b/Executable/Meal.cs
@@ -76,7 +76,7 @@ public class Meal
                 return _servings;
             }
 
-            Exception? lastException = null;
+            FoodGroupingCalculationException? lastException = null;
 
             foreach (var foodGrouping in _foodGroupings)
             {
@@ -87,14 +87,13 @@ public class Meal
                     ActualFoodGrouping = foodGrouping;
                     return _servings;
                 }
-                catch (Exception ex)
+                catch (FoodGroupingCalculationException ex)
                 {
                     lastException = ex;
-                    continue;
                 }
             }
 
-            throw lastException ?? new Exception("No FoodGroupings provided");
+            throw lastException ?? new FoodGroupingCalculationException("No FoodGroupings provided");
         }
     }
 
@@ -112,7 +111,7 @@ public class Meal
 
         if (solution == null)
         {
-            throw new Exception($"{Name} > {foodGrouping.Name} > No solution.");
+            throw new FoodGroupingCalculationException($"{Name} > {foodGrouping.Name} > No solution.");
         }
 
         (var pFoodServings, var fFoodServings, var cFoodServings) = solution.Value;
@@ -128,7 +127,7 @@ public class Meal
         {
             if (serving.NutritionalInformation.ServingUnits < 0 && !serving.IsConversion)
             {
-                throw new Exception(
+                throw new FoodGroupingCalculationException(
                     $"{Name} > {foodGrouping.Name} > " +
                     $"{serving.NutritionalInformation.ServingUnits:F2} servings in {serving.Name}.");
             }

--- a/Executable/Program.cs
+++ b/Executable/Program.cs
@@ -4,7 +4,7 @@ using SystemOfEquations.Data.TrainingWeeks.MuscleGain3;
 using SystemOfEquations.Todoist;
 
 // Set your target average daily calories here
-const decimal targetDailyCalories = 3000M;
+const decimal targetDailyCalories = 2800M;
 const decimal targetGramsProteinPerDay = 212.5M;
 
 // Automatically calculate the required adjustment

--- a/Executable/TrainingDay.cs
+++ b/Executable/TrainingDay.cs
@@ -69,9 +69,13 @@ internal record TrainingDay
 
                 return _actualNutrients.Value;
             }
+            catch (FoodGroupingCalculationException ex)
+            {
+                throw new FoodGroupingCalculationException($"{TrainingDayType} > {ex.Message}", ex);
+            }
             catch (Exception ex)
             {
-                throw new Exception($"{TrainingDayType} > {ex.Message}");
+                throw new Exception($"{TrainingDayType} > {ex.Message}", ex);
             }
         }
     }

--- a/Test/ForTargetCaloriesTests.cs
+++ b/Test/ForTargetCaloriesTests.cs
@@ -6,6 +6,13 @@ namespace Test;
 
 public class ForTargetCaloriesTests
 {
+    private static readonly FoodServing TestProteinFood = new("Test Protein",
+        new NutritionalInformation(1, ServingUnits.Gram, Cals: 4, P: 1, F: 0, CTotal: 0, CFiber: 0));
+    private static readonly FoodServing TestFatFood = new("Test Fat",
+        new NutritionalInformation(1, ServingUnits.Gram, Cals: 9, P: 0, F: 1, CTotal: 0, CFiber: 0));
+    private static readonly FoodServing TestCarbFood = new("Test Carb",
+        new NutritionalInformation(1, ServingUnits.Gram, Cals: 4, P: 0, F: 0, CTotal: 1, CFiber: 0));
+
     // Test-specific TrainingWeek implementation with predictable values
     private record TestTrainingWeek : TrainingWeekBase
     {
@@ -21,19 +28,11 @@ public class ForTargetCaloriesTests
         {
             var meals = new List<Meal>();
 
-            // Create simple test foods
-            var proteinFood = new FoodServing("Test Protein",
-                new NutritionalInformation(1, ServingUnits.Gram, Cals: 4, P: 1, F: 0, CTotal: 0, CFiber: 0));
-            var fatFood = new FoodServing("Test Fat",
-                new NutritionalInformation(1, ServingUnits.Gram, Cals: 9, P: 0, F: 1, CTotal: 0, CFiber: 0));
-            var carbFood = new FoodServing("Test Carb",
-                new NutritionalInformation(1, ServingUnits.Gram, Cals: 4, P: 0, F: 0, CTotal: 1, CFiber: 0));
-
             var foodGrouping = new FoodGrouping(
                 "Test Food Group",
-                proteinFood,
-                fatFood,
-                carbFood,
+                TestProteinFood,
+                TestFatFood,
+                TestCarbFood,
                 FoodGrouping.PreparationMethodEnum.PrepareAsNeeded);
 
             // Create meals with specified macros
@@ -61,13 +60,6 @@ public class ForTargetCaloriesTests
 
         private static IEnumerable<Meal> CreateBoundaryMeals()
         {
-            var proteinFood = new FoodServing("Test Protein",
-                new NutritionalInformation(1, ServingUnits.Gram, Cals: 4, P: 1, F: 0, CTotal: 0, CFiber: 0));
-            var fatFood = new FoodServing("Test Fat",
-                new NutritionalInformation(1, ServingUnits.Gram, Cals: 9, P: 0, F: 1, CTotal: 0, CFiber: 0));
-            var carbFood = new FoodServing("Test Carb",
-                new NutritionalInformation(1, ServingUnits.Gram, Cals: 4, P: 0, F: 0, CTotal: 1, CFiber: 0));
-
             return
             [
                 CreateMeal("Lower-limit meal", staticFat: 8M),
@@ -88,13 +80,36 @@ public class ForTargetCaloriesTests
                 var foodGrouping = new FoodGrouping(
                     $"{name} grouping",
                     [staticFatServing],
-                    proteinFood,
-                    fatFood,
-                    carbFood,
+                    TestProteinFood,
+                    TestFatFood,
+                    TestCarbFood,
                     FoodGrouping.PreparationMethodEnum.PrepareAsNeeded);
 
                 return new Meal(name, new Macros(P: 10, F: 20, C: 10), foodGrouping);
             }
+        }
+    }
+
+    private record PrecisionTrainingWeek : TrainingWeekBase
+    {
+        public PrecisionTrainingWeek() : base(
+            "Precision training week",
+            nonworkoutMeals: CreateMeals(),
+            runningMeals: CreateMeals(),
+            xfitMeals: CreateMeals())
+        {
+        }
+
+        private static IEnumerable<Meal> CreateMeals()
+        {
+            var foodGrouping = new FoodGrouping(
+                "Precision food grouping",
+                TestProteinFood,
+                TestFatFood,
+                TestCarbFood,
+                FoodGrouping.PreparationMethodEnum.PrepareAsNeeded);
+
+            return [new Meal("Precision meal", new Macros(P: 10, F: 1000, C: 1000), foodGrouping)];
         }
     }
 
@@ -237,5 +252,20 @@ public class ForTargetCaloriesTests
             new BoundaryLimitedTrainingWeek().ForTargetCalories(targetDailyCalories: 200M));
 
         Assert.Contains("Boundary-limit meal", exception.Message);
+    }
+
+    [Fact]
+    public void ForTargetCalories_SearchesUntilReachableTargetIsWithinCalorieTolerance()
+    {
+        const decimal targetDailyCalories = 10500M;
+        var trainingWeek = new PrecisionTrainingWeek().ForTargetCalories(targetDailyCalories);
+
+        var actualDailyCalories = trainingWeek.TrainingDays.Sum(
+            day => day.ActualNutrients.Cals * day.TrainingDayType.DaysTraining.Count) / 7;
+
+        Assert.InRange(
+            actualDailyCalories,
+            targetDailyCalories - 0.1M,
+            targetDailyCalories + 0.1M);
     }
 }

--- a/Test/ForTargetCaloriesTests.cs
+++ b/Test/ForTargetCaloriesTests.cs
@@ -48,6 +48,56 @@ public class ForTargetCaloriesTests
             return meals;
         }
     }
+
+    private record BoundaryLimitedTrainingWeek : TrainingWeekBase
+    {
+        public BoundaryLimitedTrainingWeek() : base(
+            "Boundary-limited training week",
+            nonworkoutMeals: CreateBoundaryMeals(),
+            runningMeals: CreateBoundaryMeals(),
+            xfitMeals: CreateBoundaryMeals())
+        {
+        }
+
+        private static IEnumerable<Meal> CreateBoundaryMeals()
+        {
+            var proteinFood = new FoodServing("Test Protein",
+                new NutritionalInformation(1, ServingUnits.Gram, Cals: 4, P: 1, F: 0, CTotal: 0, CFiber: 0));
+            var fatFood = new FoodServing("Test Fat",
+                new NutritionalInformation(1, ServingUnits.Gram, Cals: 9, P: 0, F: 1, CTotal: 0, CFiber: 0));
+            var carbFood = new FoodServing("Test Carb",
+                new NutritionalInformation(1, ServingUnits.Gram, Cals: 4, P: 0, F: 0, CTotal: 1, CFiber: 0));
+
+            return
+            [
+                CreateMeal("Lower-limit meal", staticFat: 8M),
+                CreateMeal("Boundary-limit meal", staticFat: 15M),
+            ];
+
+            Meal CreateMeal(string name, decimal staticFat)
+            {
+                var staticFatServing = new FoodServing($"{name} fixed fat",
+                    new NutritionalInformation(
+                        1,
+                        ServingUnits.Gram,
+                        Cals: staticFat * 9M,
+                        P: 0,
+                        F: staticFat,
+                        CTotal: 0,
+                        CFiber: 0));
+                var foodGrouping = new FoodGrouping(
+                    $"{name} grouping",
+                    [staticFatServing],
+                    proteinFood,
+                    fatFood,
+                    carbFood,
+                    FoodGrouping.PreparationMethodEnum.PrepareAsNeeded);
+
+                return new Meal(name, new Macros(P: 10, F: 20, C: 10), foodGrouping);
+            }
+        }
+    }
+
     [Theory]
     [InlineData(2200, 5)]   // Requires searching below the old lower bound
     [InlineData(2450, 10)]  // ~90% - near lower bound  
@@ -178,5 +228,14 @@ public class ForTargetCaloriesTests
 
         // Assert - ratio should be preserved (within small tolerance for rounding)
         Assert.InRange(adjustedRatio, baseRatio * 0.98M, baseRatio * 1.02M);
+    }
+
+    [Fact]
+    public void ForTargetCalories_ReportsFoodGroupingAtReachableBoundary()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new BoundaryLimitedTrainingWeek().ForTargetCalories(targetDailyCalories: 200M));
+
+        Assert.Contains("Boundary-limit meal", exception.Message);
     }
 }

--- a/Test/MuscleGain3TrainingAfter1MealTests.cs
+++ b/Test/MuscleGain3TrainingAfter1MealTests.cs
@@ -1,0 +1,48 @@
+using SystemOfEquations.Data.TrainingWeeks.MuscleGain3;
+
+namespace Test;
+
+public class MuscleGain3TrainingAfter1MealTests
+{
+    [Fact]
+    public void ForTargetCalories_ReachesRequestedWeeklyAverage()
+    {
+        const decimal targetDailyCalories = 2800M;
+        var trainingWeek = new MuscleGain3TrainingAfter1Meal(targetGramsProteinPerDay: 212.5M)
+            .ForTargetCalories(targetDailyCalories);
+
+        var weeklyCalories = trainingWeek.TrainingDays.Sum(
+            day => day.ActualNutrients.Cals * day.TrainingDayType.DaysTraining.Count);
+        var averageDailyCalories = weeklyCalories / 7;
+
+        Assert.InRange(averageDailyCalories, targetDailyCalories - 1M, targetDailyCalories + 1M);
+    }
+
+    [Fact]
+    public void ForTargetCalories_ExplainsTheLimitingFoodGroupingWhenTargetCannotBeReached()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new MuscleGain3TrainingAfter1Meal(targetGramsProteinPerDay: 212.5M)
+                .ForTargetCalories(2000M));
+
+        Assert.Contains("Limiting calculation:", exception.Message);
+        Assert.Contains("Non-weight training day", exception.Message);
+        Assert.Contains("Waking", exception.Message);
+        Assert.Contains("Blueberry oatmeal shake", exception.Message);
+        Assert.Contains("oats", exception.Message);
+        Assert.NotNull(exception.InnerException);
+    }
+
+    [Fact]
+    public void ForTargetCalories_CanCalculateRunningDayNutrients()
+    {
+        var exception = Record.Exception(() =>
+        {
+            var trainingWeek = new MuscleGain3TrainingAfter1Meal(targetGramsProteinPerDay: 212.5M)
+                .ForTargetCalories(3000M);
+            _ = trainingWeek.RunningDay.ActualNutrients;
+        });
+
+        Assert.Null(exception);
+    }
+}

--- a/Test/MuscleGain3TrainingAfter1MealTests.cs
+++ b/Test/MuscleGain3TrainingAfter1MealTests.cs
@@ -15,7 +15,7 @@ public class MuscleGain3TrainingAfter1MealTests
             day => day.ActualNutrients.Cals * day.TrainingDayType.DaysTraining.Count);
         var averageDailyCalories = weeklyCalories / 7;
 
-        Assert.InRange(averageDailyCalories, targetDailyCalories - 1M, targetDailyCalories + 1M);
+        Assert.InRange(averageDailyCalories, targetDailyCalories - 0.1M, targetDailyCalories + 0.1M);
     }
 
     [Fact]
@@ -44,5 +44,19 @@ public class MuscleGain3TrainingAfter1MealTests
         });
 
         Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ForTargetCalories_ExplainsLimitingFoodGroupingWhenFallbackSwitchSkipsTarget()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new MuscleGain3TrainingAfter1Meal(targetGramsProteinPerDay: 212.5M)
+                .ForTargetCalories(3216M));
+
+        Assert.Contains("Limiting calculation:", exception.Message);
+        Assert.Contains("Running day", exception.Message);
+        Assert.Contains("40 minutes after workout", exception.Message);
+        Assert.Contains("English muffins and pasta", exception.Message);
+        Assert.NotNull(exception.InnerException);
     }
 }

--- a/Test/UnitTest1.cs
+++ b/Test/UnitTest1.cs
@@ -101,7 +101,31 @@ public class UnitTest1
         var meal = new Meal("test meal", targetMacros, new FallbackChain(impossibleFoodGrouping1, impossibleFoodGrouping2));
 
         // Should throw when trying to calculate servings since all FoodGroupings fail
-        Assert.Throws<Exception>(() => meal.Servings.ToList());
+        Assert.Throws<FoodGroupingCalculationException>(() => meal.Servings.ToList());
+    }
+
+    [Fact]
+    public void Meal_Should_Not_Try_Fallback_For_Unexpected_Calculation_Error()
+    {
+        var invalidFoodGrouping = new FoodGrouping(
+            "invalid",
+            staticServings: null!,
+            pFood,
+            fFood,
+            cFood,
+            FoodGrouping.PreparationMethodEnum.PrepareAsNeeded);
+        var workingFoodGrouping = new FoodGrouping(
+            "working",
+            pFood,
+            fFood,
+            cFood,
+            FoodGrouping.PreparationMethodEnum.PrepareAsNeeded);
+        var meal = new Meal(
+            "test meal",
+            new Macros(P: 1, F: 2, C: 3),
+            new FallbackChain(invalidFoodGrouping, workingFoodGrouping));
+
+        Assert.Throws<NullReferenceException>(() => meal.Servings.ToList());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- update the Muscle Gain 3 meal configuration and target it at 2,800 calories per day
- add conversion-food fallbacks for the affected toast, rice, oatmeal, cereal, workout, and bedtime meal paths
- report the closest achievable average and limiting day, meal, food grouping, and serving for infeasible targets
- preserve diagnostic context when a successful fallback switch creates an unreachable calorie gap
- distinguish expected food-grouping infeasibility from unexpected calculation defects
- add regression coverage for target precision, boundary selection, fallback-switch gaps, and 2,800-calorie scaling

## Testing

- `dotnet test --no-restore` (129 passed)
- `dotnet build --configuration Release --no-restore` (0 warnings, 0 errors)
- `dotnet format --verify-no-changes --no-restore`
- `dotnet run --project Executable --no-build -- smoke` (actual weekly average: 2,800 calories/day)
- GitHub `Build and Test` and `GitGuardian Security Checks` passed